### PR TITLE
approval: remove passwords from json responses, todo: remove from UI

### DIFF
--- a/internal/ui/approve_new_account.go
+++ b/internal/ui/approve_new_account.go
@@ -82,6 +82,7 @@ func (t *ApproveNewAccountCtx) ClickResponse(replyCh chan *core2.NewAccountRespo
 				return
 			}
 			// Approval, check that passwords match
+			// TODO! Remove passwords from here
 			pw := t.Password()
 			cpw := t.ConfirmPassword()
 			if len(pw) == 0 || len(cpw) == 0 {
@@ -91,7 +92,6 @@ func (t *ApproveNewAccountCtx) ClickResponse(replyCh chan *core2.NewAccountRespo
 				log.Println("Passwords do not match")
 			} else {
 				reply.Approved = true
-				reply.Password = pw
 				t.Reset()
 				replyCh <- reply
 				return

--- a/internal/ui/approve_sign_data.go
+++ b/internal/ui/approve_sign_data.go
@@ -88,7 +88,6 @@ func (t *ApproveSignDataCtx) ClickResponse(res chan *core2.SignDataResponse) {
 			reply.Approved = false
 		} else if answer == 2 {
 			reply.Approved = true
-			reply.Password = t.Password()
 		}
 		res <- reply
 		t.Reset()

--- a/internal/ui/approve_tx.go
+++ b/internal/ui/approve_tx.go
@@ -340,13 +340,13 @@ func (t *ApproveTxCtx) ClickResponse(responseCh chan *core2.SignTxResponse) {
 			reply.Approved = false
 		} else { // Approve
 			// TODO handle errors here
+			// TODO, remove PASSWORD from UI
 			// We might want to validate already in the clicked() method, and pass the
 			// replyTx over the channel
 			replyTx, _ := t.getNewTx()
 			reply.Transaction = replyTx
 			reply.Approved = true
 
-			reply.Password = t.Password()
 		}
 		t.Reset()
 		responseCh <- reply


### PR DESCRIPTION
Removes some leftover references to passwords which were removed from the geth definitions of responses a while back